### PR TITLE
Use different note fields for different office contacts

### DIFF
--- a/ca/people.py
+++ b/ca/people.py
@@ -63,19 +63,22 @@ class CanadaPersonScraper(Scraper):
       if fax:
         m.add_contact('fax', fax, 'legislature')
 
-      for li in mp_page.xpath('//div[@class="constituencyoffices"]//li'):
+      for i, li in enumerate(mp_page.xpath('//div[@class="constituencyoffices"]//li')):
         spans = li.xpath('./span[not(@class="spacer")]')
+        note = "constituency"
+        if i:
+          note += ' ({})'.format(i+1)
         m.add_contact('address', '\n'.join([
           spans[0].text_content(), # address line 1
           spans[1].text_content(), # address line 2
           spans[2].text_content(), # city, region
           spans[3].text_content(), # postal code
-        ]), 'constituency')
+        ]), note)
         voice = li.xpath('string(./span[contains(text(), "Telephone:")])').replace('Telephone: ', '')
         if voice:
-          m.add_contact('voice', voice, 'constituency')
+          m.add_contact('voice', voice, note)
         fax = li.xpath('string(./span[contains(text(), "Fax:")])').replace('Fax: ', '')
         if fax:
-          m.add_contact('fax', fax, 'constituency')
+          m.add_contact('fax', fax, note)
 
       yield m

--- a/patch.py
+++ b/patch.py
@@ -29,12 +29,9 @@ _contact_details['items']['properties']['value']['conditionalPattern'] = [
   # (re.compile(r'\n(?:(?:\d+[A-C]?|St\.|a|aux|de|des|du|la|sur|\p{Lu}|(?:D'|d'|L'|l'|Mc|Qu')?\p{L}+(?:'s|!)?)(?:--?| - | ))+(?:BC|AB|MB|SK|ON|QC|NB|PE|NS|NL|YT|NT|NU)(?:  [ABCEGHJKLMNPRSTVXY][0-9][ABCEGHJKLMNPRSTVWXYZ] [0-9][ABCEGHJKLMNPRSTVWXYZ][0-9])?\Z', flags=re.U),
   #  lambda x: x['type'] == 'address'),
 ]
-_contact_details['items']['properties']['note']['enum'] = [
-  'constituency',
-  'legislature',
-  'office',
-  'residence',
-]
+_contact_details['items']['properties']['note']['compiledPattern'] = re.compile(
+  r'^(?:constituency|legislature|office|residence)(?: \(\d\))?$')
+
 _contact_details['items']['additionalProperties'] = False
 
 _links['items']['properties']['url']['blank'] = False


### PR DESCRIPTION
This is unfortunately untested -- I spent a long time swearing and trying to set up a development environment, but couldn't get to the point where I could get the (unmodified, before-my-changes) scraper working. The final error, on which I gave up, was with several of the DatetimeValidator monkey-patch methods in patch.py throwing exceptions.
