### PR TITLE
Check that photo URL actually exist -- sometimes it doesn't

### DIFF
--- a/ca/people.py
+++ b/ca/people.py
@@ -50,7 +50,9 @@ class CanadaPersonScraper(Scraper):
         m.add_contact('email', email, None)
       elif name == 'Adam Vaughan':
         m.add_contact('email', 'Adam.Vaughan@parl.gc.ca', None)
-      m.image = photo
+
+      if photo and requests.head(photo).status_code == 200:
+        m.image = photo
 
       personal_url = mp_page.xpath('//a[contains(@title, "Personal Web Site")]/@href')
       if personal_url:


### PR DESCRIPTION
For new MPs who don't have an official photo yet, parl.gc.ca photos are actually broken links. (A 302 to a 404, to be precise.) So this makes a HEAD request to make sure the URL isn't broken.
