### PR TITLE
Added division ids for moncton posts

### DIFF
--- a/ca_nb_moncton/__init__.py
+++ b/ca_nb_moncton/__init__.py
@@ -13,11 +13,11 @@ class Moncton(CanadianJurisdiction):
     def get_organizations(self):
         organization = Organization(self.name, classification=self.classification)
 
-        organization.add_post(role='Mayor', label='Moncton')
+        organization.add_post(role='Mayor', label='Moncton', division_id=self.division_id)
         for i in range(2):
-            organization.add_post(role='Councillor at Large', label='Moncton (seat {})'.format(i + 1))
+            organization.add_post(role='Councillor at Large', label='Moncton (seat {})'.format(i + 1), division_id=self.division_id)
         for i in range(4):
             for j in range(2):
-                organization.add_post(role='Councillor', label='Ward {} (seat {})'.format(i + 1, j + 1))
+                organization.add_post(role='Councillor', label='Ward {} (seat {})'.format(i + 1, j + 1), division_id='{}/ward:{}'.format(self.division_id, i + 1))
 
         yield organization


### PR DESCRIPTION
Tried testing the other PR against moncton, and realized this needed manual adding. If the style isn't how you like it, just say so, and I'll fix it. Also, if you *do* have a preferred style, perhaps we could codify that in an `.editorconfig` file, so other just get it for free?