### PR TITLE
Toronto: bugfix for cancelled meeting names in IncrementalEvent scraper

### DIFF
--- a/ca_on_toronto/events-incremental.py
+++ b/ca_on_toronto/events-incremental.py
@@ -60,6 +60,9 @@ class TorontoIncrementalEventScraper(CanadianScraper):
         def sanitize_org_name(org_name):
             # Some meetings preceded with legend, ie "S:" for special meetings.
             org_name = re.sub(r'^[A-Z]: +', '', org_name)
+            # Strip suffix (ie. cancelled meetings)
+            org_name = re.sub(r'\u2014.*$', '', org_name)
+            org_name = org_name.strip()
             # Special case for city council name
             org_name = self.jurisdiction.name if org_name == 'City Council' else org_name
             return org_name


### PR DESCRIPTION
![calendar screenshot](https://imgur.com/bsnTnhf.png])

    20:36:27 ERROR pupa: cannot resolve pseudo id to Organization: ~{"name": "Property Standards - Scarborough Panel   \u2014 Cancelled"}

Was getting the above output for a cancelled event. Seems we need to ignore after the long dash char.