### PR TITLE
Toronto: Workaround for dead links on councillor photos

### DIFF
--- a/ca_on_toronto/people.py
+++ b/ca_on_toronto/people.py
@@ -6,7 +6,7 @@ COUNCIL_PAGE = 'http://www1.toronto.ca/wps/portal/contentonly?vgnextoid=c3a83293
 
 class TorontoPersonScraper(CSVScraper):
     csv_url = 'http://www1.toronto.ca/City%20Of%20Toronto/Information%20&%20Technology/Open%20Data/Data%20Sets/Assets/Files/Toronto_Elected_Officials.csv'
-    header_converter = lambda self, s: 'district name' if s == 'District ID' else None if s == 'District name' else s.lower()
+    district_id_to_district_name = 'Ward {}'
     other_names = {
         'Norman Kelly': ['Norm Kelly'],
         'Justin Di Ciano': ['Justin J. Di Ciano'],

--- a/ca_on_toronto/people.py
+++ b/ca_on_toronto/people.py
@@ -14,4 +14,4 @@ class TorontoPersonScraper(CSVScraper):
 
     # TODO: Remove once original file is fixed.
     # See: https://github.com/opencivicdata/scrapers-ca/issues/155#issuecomment-169855328
-    csv_url = 'https://gist.githubusercontent.com/patcon/70656c30f544efd3673a/raw/4fc61631243da8dea0a4f4b31f5d5a5b99f26c75/Toronto_Elected_Officials.csv'
+    csv_url = 'https://gist.githubusercontent.com/patcon/70656c30f544efd3673a/raw/7ed589561c6c68203dd1cbbcefa21cba4dc34f63/Toronto_Elected_Officials.csv'


### PR DESCRIPTION
Also, did I understand you correctly that the district id was supposed to be numeric only, and the City would be changing this in their own CSV?

I'd [made this change earlier](https://gist.github.com/patcon/70656c30f544efd3673a/revisions#diff-8a05bcb02b17075dc19f0c2ceb9091d3L1), and if it's how you actually wanted it, then the header_conversion can be replaced, as I did in the other commit in this PR.

Anyhow, this is conflating issues, so let me know if I misunderstood and you'd like them separated :)