### PR TITLE
Toronto: Add agenda item type as subject

### DIFF
--- a/ca_on_toronto/events-incremental.py
+++ b/ca_on_toronto/events-incremental.py
@@ -155,6 +155,7 @@ class TorontoIncrementalEventScraper(CanadianScraper):
                     for i, item in enumerate(agenda_items):
 
                         a = e.add_agenda_item(item['title'])
+                        a.add_subject(item['type'])
                         a['order'] = str(i)
 
                         def is_vote_event(item):


### PR DESCRIPTION
http://app.toronto.ca/tmmis/viewPublishedReport.do?function=getAgendaReport&meetingId=10898

As seen in the link above, each agenda item has a type in its header. From what I've seen, there are a few options it can be:

* ACTION
* Information
* Presentation