### PR TITLE
Rename current toronto bill scraper to `votes`

### DIFF
--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -26,7 +26,7 @@ vote_map = {
 }
 
 
-class TorontoBillScraper(CanadianScraper):
+class TorontoVoteScraper(CanadianScraper):
     def scrape(self):
         # We store agenda items as bills, because Pupa can only have votes on
         # bills. Toronto has no bills anyhow.

--- a/utils.py
+++ b/utils.py
@@ -302,7 +302,7 @@ class CanadianJurisdiction(Jurisdiction):
 
     def __init__(self):
         super(CanadianJurisdiction, self).__init__()
-        for module, name in (('people', 'Person'), ('bills', 'Bill'), ('committees', 'Committee'), ('events-incremental', 'IncrementalEvent')):
+        for module, name in (('people', 'Person'), ('bills', 'Bill'), ('votes', 'Vote'), ('committees', 'Committee'), ('events-incremental', 'IncrementalEvent')):
             try:
                 class_name = self.__class__.__name__ + name + 'Scraper'
                 self.scrapers[module] = getattr(__import__(self.__module__ + '.' + module, fromlist=[class_name]), class_name)


### PR DESCRIPTION
I'm currently working on a new scraper for bills, which involves scraping data from [individual agenda item urls/version](http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2016.HB10.3) retrieved from an [advanced search of agenda items](http://app.toronto.ca/tmmis/findAgendaItem.do?function=doPrepare)

The upside of this is that we can more easily scrape all motions and all votes, even when a full per-councillor vote was not called. The current bill scraper only parses data from a vote record search, which only contains data about full, per-councillor votes. So lots of pass/fail information from agenda item motions is not collected.

For clarity, I'd like to rename the current bill scraper to "votes", and I'll soon submit a new scraper for bills, which will scrape based on chronological search, and provide more parsed data on agenda item history (motions and actions)