### PR TITLE
Toronto: Add pseudonym for councillor Michelle Holland

### DIFF
--- a/ca_on_toronto/people.py
+++ b/ca_on_toronto/people.py
@@ -10,4 +10,5 @@ class TorontoPersonScraper(CSVScraper):
     other_names = {
         'Norman Kelly': ['Norm Kelly'],
         'Justin Di Ciano': ['Justin J. Di Ciano'],
+        'Michelle Berardinetti': ['Michelle Holland'],
     }


### PR DESCRIPTION
Ref: http://www.insidetoronto.com/news-story/6330408-scarborough-southwest-councillor-now-to-be-known-as-michelle-holland-for-city-business/