### PR TITLE
Add explicit note for website link on person object

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -83,8 +83,8 @@ organization_contact_details['maxItems'] = 0
 organization_links['maxItems'] = 0
 # A person should not have contact details.
 person_contact_details['maxItems'] = 0
-# A person should not have notes on links.
-person_links['items']['properties']['note']['enum'] = ['']
+# A person should only have a link note for the canonical website.
+person_links['items']['properties']['note']['enum'] = ['', 'web site']
 # A person should have, in most cases, at most one non-social media link, and
 # should have at most one link per social media website.
 person_links['maxMatchingItems'] = [

--- a/utils.py
+++ b/utils.py
@@ -278,7 +278,7 @@ class CSVScraper(CanadianScraper):
                 if row.get('source url'):
                     p.add_source(row['source url'])
                 if row.get('website'):
-                    p.add_link(row['website'])
+                    p.add_link(row['website'], note='web site')
                 p.add_contact('email', row['email'])
                 if lines:
                     p.add_contact('address', '\n'.join(lines), 'legislature')


### PR DESCRIPTION
The loaddata command for councilmatic expects the link that is a website to be specified:

https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/management/commands/loaddata.py#L664-L665

This strikes me as sensible, as there could be many links. Can I relax the enum (which currently ensures website notes are blank) and add a note for the website url from the CSVScraper?