### PR TITLE
Toronto: Scrape full_text of agenda items for councilmatic

### DIFF
--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -73,6 +73,9 @@ class TorontoBillScraper(CanadianScraper):
 
             agenda_item_versions = self.agendaItemVersions(agenda_item['url'])
 
+            # Use one version's full_text (will be most recent)
+            b.extras['full_text'] = agenda_item_versions[0]['full_text']
+
             for version in agenda_item_versions:
                 action_date = self.toDate(version['date'])
 
@@ -278,6 +281,7 @@ class TorontoBillScraper(CanadianScraper):
         version.update({
             'type': page.xpath("//table[@class='border'][1]//td[2]")[0].text_content().strip().lower(),
             'action': page.xpath("//table[@class='border'][1]//td[3]")[0].text_content().strip(),
+            'full_text': etree.tostring(page, pretty_print=True).decode(),
         })
 
         wards = page.xpath("//table[@class='border'][1]//td[5]")[0].text_content().strip().lower()


### PR DESCRIPTION
We need to have a "full_text" key in extras to get haystack search working properly with councilmatic,

Ref: https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/management/commands/loaddata.py#L378-L379

incoming PR