### PR TITLE
Toronto: Scrape non-tallied vote records from agenda items

### DIFF
--- a/ca_on_toronto/__init__.py
+++ b/ca_on_toronto/__init__.py
@@ -12,34 +12,36 @@ class Toronto(TorontoJurisdiction):
     name = 'Toronto City Council'
     url = 'http://www.toronto.ca'
     check_sessions = True
-    legislative_sessions = [
+    legislative_sessions = []
+
+    def __init__(self):
+        super(Toronto, self).__init__()
         # TODO: Accommodate legacy format pages. (bad old PDF days)
         # {'identifier': '1998-2000'},
         # {'identifier': '2000-2003'},
         # {'identifier': '2003-2006'},
-        {
-            'identifier': '2006-2010',
-            'name': '2006-2010',
-            'start_date': '2006-12-01',
-            'end_date': '2010-11-30',
-            'classification': 'primary',
-        },
-        {
-            'identifier': '2010-2014',
-            'name': '2010-2014',
-            'start_date': '2010-12-01',
-            'end_date': '2014-11-30',
-            'classification': 'primary',
-        },
-        {
-            'identifier': '2014-2018',
-            'name': '2014-2018',
-            'start_date': '2014-12-01',
-            'end_date': '2018-11-30',
-            'classification': 'primary',
-        },
-    ]
+        self.legislative_sessions = [self.leg_session(session) for session in self.sessions()]
 
     def get_session_list(self):
-        response = requests.get('http://app.toronto.ca/tmmis/getAdminReport.do?function=prepareMemberVoteReport')
-        return lxml.html.fromstring(response.text).xpath('//select[@name="termId"][1]/option/text()')
+        return [session['term_name'] for session in self.sessions()]
+
+    def leg_session(self, session):
+        leg_session = {}
+        start_year, end_year = session['term_name'].split('-')
+        leg_session['identifier'] = session['term_name']
+        leg_session['name'] = session['term_name']
+        leg_session['start_date'] = '{}-12-01'.format(start_year)
+        leg_session['end_date'] = '{}-11-30'.format(end_year)
+        leg_session['classification'] = 'primary'
+
+        return leg_session
+
+    def sessions(self):
+        response = requests.get('http://app.toronto.ca/tmmis/findAgendaItem.do?function=doPrepare')
+        page = lxml.html.fromstring(response.text)
+        # Remove the blank option label and sort chronologically
+        for option in reversed(page.xpath('//select[@name="termId"][1]/option')[1:]):
+            session = {}
+            session['termId'] = option.attrib['value']
+            session['term_name'] = option.text
+            yield session

--- a/ca_on_toronto/__init__.py
+++ b/ca_on_toronto/__init__.py
@@ -20,12 +20,12 @@ class Toronto(TorontoJurisdiction):
         # {'identifier': '1998-2000'},
         # {'identifier': '2000-2003'},
         # {'identifier': '2003-2006'},
-        self.legislative_sessions = [self.leg_session(session) for session in self.sessions()]
+        self.legislative_sessions = [self.legislative_session(session) for session in self.sessions()]
 
     def get_session_list(self):
         return [session['term_name'] for session in self.sessions()]
 
-    def leg_session(self, session):
+    def legislative_session(self, session):
         leg_session = {}
         start_year, end_year = session['term_name'].split('-')
         leg_session['identifier'] = session['term_name']

--- a/ca_on_toronto/bills-incremental.py
+++ b/ca_on_toronto/bills-incremental.py
@@ -3,4 +3,4 @@ import datetime
 
 
 class TorontoIncrementalBillScraper(TorontoBillScraper):
-    start_date = datetime.datetime.today() - datetime.timedelta(days=7)
+    start_date = datetime.datetime.today() - datetime.timedelta(days=6)

--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -166,8 +166,12 @@ class TorontoBillScraper(CanadianScraper):
         function_qs = re.findall(r'var f = "(.*)";', script_text)
         agenda_item_id_qs = re.findall(r'agendaItemId:"(.*)"', script_text)
         url_template = 'http://app.toronto.ca/tmmis/viewAgendaItemDetails.do?function={}&agendaItemId={}'
-        for i, f, id in sorted(zip(index_qs, function_qs, agenda_item_id_qs), key=lambda tup: tup[2]):
-            agenda_item_version_url = url_template.format(f, id)
+        for i, func, id in sorted(zip(index_qs, function_qs, agenda_item_id_qs), key=lambda tup: tup[2]):
+            # Decision document only rarely has motion breakdown.
+            if func == 'getDecisionDocumentItemPreview':
+                func = 'getMinutesItemPreview'
+
+            agenda_item_version_url = url_template.format(func, id)
             version = self.agendaItemVersion(agenda_item_version_url)
 
             xpr = '//div[@id="header{}"]'.format(i)
@@ -177,6 +181,7 @@ class TorontoBillScraper(CanadianScraper):
             version.update({
                 'responsible_org': org,
                 'date': date,
+                'url': agenda_item_version_url,
             })
 
             if 'Origin' in version['sections']:

--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -309,6 +309,10 @@ class TorontoBillScraper(CanadianScraper):
 
         version.update({'wards': wards})
 
+        header_elem = page.xpath("//table[@class='border']")[0]
+        page.remove(header_elem)
+        version['full_text'] = etree.tostring(page, pretty_print=True).decode()
+
         section_nodes = page.xpath("//table[@width=620 and .//font[@face='Arial' and @size=3] and .//tr[3]]")
         sections = {}
         for node in section_nodes:

--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -183,10 +183,12 @@ class TorontoBillScraper(CanadianScraper):
                 origin_text = version['sections']['Origin']
                 intro_date_re = re.compile('\((.+?)\) .+')
                 intro_date = re.match(intro_date_re, origin_text).group(1)
-                intro_version = copy(version)
+                intro_version = {}
                 intro_version.update({
                     'date': intro_date,
                     'action': 'Introduced',
+                    'sections': {},
+                    'responsible_org': org,
                 })
                 yield intro_version
 

--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -120,18 +120,18 @@ class TorontoBillScraper(CanadianScraper):
 
             agenda_item_versions = self.agendaItemVersions(agenda_item['url'])
 
-            # Use one version's full_text (will be most recent)
-            b.extras['full_text'] = agenda_item_versions[-1]['full_text']
+            # Use most recent agenda item version for summary and fulltext
+            recent_version = agenda_item_versions[-1]
+            b.extras['full_text'] = recent_version['full_text']
+            for title, content in recent_version['sections'].items():
+                if 'Summary' in title:
+                    date = self.toDate(recent_version['date'])
+                    b.add_abstract(content, note='', date=date)
 
             for version in agenda_item_versions:
                 action_date = self.toDate(version['date'])
 
                 for title, content in version['sections'].items():
-                    if 'Summary' in title:
-                        # TODO: Investigate whether these vary between versions, as
-                        # we perhaps don't need to add one for each
-                        b.add_abstract(content, note='', date=action_date)
-
                     if 'Motions' in title:
                         motions = content
                         for i, motion in enumerate(motions):

--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -74,7 +74,7 @@ class TorontoBillScraper(CanadianScraper):
             agenda_item_versions = self.agendaItemVersions(agenda_item['url'])
 
             # Use one version's full_text (will be most recent)
-            b.extras['full_text'] = agenda_item_versions[0]['full_text']
+            b.extras['full_text'] = agenda_item_versions[-1]['full_text']
 
             for version in agenda_item_versions:
                 action_date = self.toDate(version['date'])

--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from collections import defaultdict
-from copy import copy
 from pupa.scrape import Bill, VoteEvent
 from utils import CanadianScraper
 
@@ -41,8 +40,8 @@ ACTION_CLASSIFICATION = {
     'Adopt Minutes': 'passage',
     'Adopt Order Paper as Amended': 'passage',
     'Adopt Order Paper': 'passage',
-    'Amend Item (Additional)': 'ammendment-passage',
-    'Amend Item': 'ammendment-passage',
+    'Amend Item (Additional)': 'amendment-passage',
+    'Amend Item': 'amendment-passage',
     'Amend Motion': None,
     'Amend the Order Paper': None,
     'Confirm Order': None,
@@ -64,8 +63,7 @@ ACTION_CLASSIFICATION = {
     'Waive Notice': None,
     'Waive Referral': None,
     'Withdraw a Motion': None,
-    'Withdraw a Motion': None,
-    'Withdraw an Item"': 'withdrawal',
+    'Withdraw an Item': 'withdrawal',
 }
 
 RESULT_MAP = {
@@ -158,13 +156,13 @@ class TorontoBillScraper(CanadianScraper):
         title, primary_role, primary_sponsor, secondary_role, secondary_sponsor = re.match(agenda_item_title_re, title).groups()
 
         bill = {
-                'identifier': agenda_item['Item No.'],
-                'title': title,
-                'legislative_session': agenda_item['session'],
-                # TODO: Add agenda_item type to OCD
-                'classification': 'bill',
-                'from_organization': {'name': self.jurisdiction.name},
-                }
+            'identifier': agenda_item['Item No.'],
+            'title': title,
+            'legislative_session': agenda_item['session'],
+            # TODO: Add agenda_item type to OCD
+            'classification': 'bill',
+            'from_organization': {'name': self.jurisdiction.name},
+        }
 
         b = Bill(**bill)
         b.add_source(agenda_item['url'], note='web')
@@ -179,12 +177,12 @@ class TorontoBillScraper(CanadianScraper):
         version = agenda_item_version
         date = self.toDate(version['date'])
         v = VoteEvent(
-                motion_text=motion['title_text'],
-                result=RESULT_MAP[motion['result']],
-                classification=motion['action'],
-                start_date=date,
-                legislative_session=version['session'],
-                )
+            motion_text=motion['title_text'],
+            result=RESULT_MAP[motion['result']],
+            classification=motion['action'],
+            start_date=date,
+            legislative_session=version['session'],
+        )
 
         if motion['mover']:
             v.extras['mover'] = motion['mover']
@@ -423,6 +421,7 @@ class TorontoBillScraper(CanadianScraper):
             title_text = title.text_content().replace(u'\xa0', ' ').strip()
             body_text = body.text_content()
             if 'Motion to' not in title_text:
+                # Outputting non-motion actions for inspection
                 print(title_text)
                 continue
             motion = re.match(motion_re, title_text).groupdict()

--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -427,7 +427,7 @@ class TorontoBillScraper(CanadianScraper):
         motions = []
         motion_titles = content_etree.xpath('.//i')
         # TODO: Body not always present, so figure out how to collect it
-        motion_bodies = content_etree.xpath('.//div[@class="wep"]') # NOQA
+        motion_bodies = content_etree.xpath('.//div[@class="wep"]')  # NOQA
         for title in motion_titles:
             title_text = title.text_content().replace(u'\xa0', ' ').strip()
             if 'Motion to' not in title_text:

--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -32,7 +32,7 @@ ACTION_CLASSIFICATION = {
     'Without Recs': None,
     'Waive Referral': None,
     # Made this one up
-    'Introduced': 'introduction',
+    'Filed': 'filing',
     # Motion actions
     'Add New Business at Committee': 'introduction',
     'Adopt Item as Amended': 'passage',
@@ -126,7 +126,7 @@ class TorontoBillScraper(CanadianScraper):
                         if is_recommendation(version):
                             action_class = 'committee-passage-favorable'
 
-                if version['action'] == 'Introduced':
+                if version['action'] == 'Filed':
                     action_description = version['action']
                     action_class = ACTION_CLASSIFICATION.get(version['action'])
                     b.add_action(
@@ -279,16 +279,16 @@ class TorontoBillScraper(CanadianScraper):
 
             if 'Origin' in version['sections']:
                 origin_text = version['sections']['Origin']
-                intro_date_re = re.compile('\((.+?)\) .+')
-                intro_date = re.match(intro_date_re, origin_text).group(1)
-                intro_version = {}
-                intro_version.update({
-                    'date': intro_date,
-                    'action': 'Introduced',
+                filing_date_re = re.compile('\((.+?)\) .+')
+                filing_date = re.match(filing_date_re, origin_text).group(1)
+                filing_version = {}
+                filing_version.update({
+                    'date': filing_date,
+                    'action': 'Filed',
                     'sections': {},
                     'responsible_org': org,
                 })
-                yield intro_version
+                yield filing_version
 
             yield version
 

--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -126,6 +126,16 @@ class TorontoBillScraper(CanadianScraper):
                         if is_recommendation(version):
                             action_class = 'committee-passage-favorable'
 
+                if version['action'] == 'Introduced':
+                    action_description = version['action']
+                    action_class = ACTION_CLASSIFICATION.get(version['action'])
+                    b.add_action(
+                        action_description,
+                        action_date,
+                        organization={'name': responsible_org},
+                        classification=action_class
+                    )
+
                 for title, content in version['sections'].items():
                     if 'Motions' in title:
                         motions = content

--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -416,17 +416,17 @@ class TorontoBillScraper(CanadianScraper):
     def parseAgendaItemVersionMotions(self, content_etree):
         motions = []
         motion_titles = content_etree.xpath('.//i')
+        # TODO: Body not always present, so figure out how to collect it
         motion_bodies = content_etree.xpath('.//div[@class="wep"]')
-        for title, body in zip(motion_titles, motion_bodies):
+        for title in motion_titles:
             title_text = title.text_content().replace(u'\xa0', ' ').strip()
-            body_text = body.text_content()
             if 'Motion to' not in title_text:
                 # Outputting non-motion actions for inspection
                 print(title_text)
                 continue
             motion = re.match(motion_re, title_text).groupdict()
             motion['title_text'] = title_text
-            motion['body_text'] = body_text
+            motion['body_text'] = ''
             motions.append(motion)
 
         return motions

--- a/ca_on_toronto/bills.py
+++ b/ca_on_toronto/bills.py
@@ -427,7 +427,7 @@ class TorontoBillScraper(CanadianScraper):
         motions = []
         motion_titles = content_etree.xpath('.//i')
         # TODO: Body not always present, so figure out how to collect it
-        motion_bodies = content_etree.xpath('.//div[@class="wep"]')
+        motion_bodies = content_etree.xpath('.//div[@class="wep"]') # NOQA
         for title in motion_titles:
             title_text = title.text_content().replace(u'\xa0', ' ').strip()
             if 'Motion to' not in title_text:

--- a/ca_on_toronto/events-incremental.py
+++ b/ca_on_toronto/events-incremental.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from utils import CanadianScraper
 
-from pupa.scrape import Bill, Event
+from pupa.scrape import Event
 from urllib.parse import parse_qs, urlparse
 import lxml.html
 import datetime as dt
@@ -14,7 +14,6 @@ from .constants import (
     AGENDA_LIST_STANDARD_TEMPLATE,
     AGENDA_FULL_COUNCIL_TEMPLATE,
     AGENDA_LIST_COUNCIL_TEMPLATE,
-    AGENDA_ITEM_TEMPLATE,
 )
 
 
@@ -158,7 +157,6 @@ class TorontoIncrementalEventScraper(CanadianScraper):
                             else:
                                 return raw.split(', ')
 
-                        wards = normalize_wards(item['wards'])
                         identifier_regex = re.compile(r'^[0-9]{4}\.([A-Z]{2}[0-9]+\.[0-9]+)$')
                         [full_identifier] = [id for id in full_identifiers if identifier_regex.match(id).group(1) == item['identifier']]
                         a.add_bill(full_identifier)


### PR DESCRIPTION
Searching [Vote Records for 2016-01-04](http://app.toronto.ca/tmmis/getAdminReport.do?function=getMemberVoteReport&memberId=2&fromDate=2016-01-04&toDate=2016-01-04) (using Paul Ainslie as an example) shows the "Government Management Committee" meeting recorded two votes: [GM9.4](http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2016.GM9.4) and [GM9.5](http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2016.GM9.5)

But looking at the text of the other items ([GM9.1](http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2016.GM9.1), [GM9.2](http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2016.GM9.2), [GM9.3](http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2016.GM9.3)), we see that there was also at least one vote (motion) for each that passed.

So it seems that vote records only show up in the search when a full vote was taken (usually initiated by Rob Ford). So in order to get a full vote record (even though we won't know individual councillor's votes), we'll have to scrape the AgendaItemHistory pages for past votes.

Another option would be to open up discussions with some of the councillors on whether it would be possible to get full votes on all items. If not, perhaps we could investigate why this might be (ie. perhaps the process is unnecessarily slower and oral, rather than digital)

cc: @dougestey, as this lack of data will affect your design decisions (perhaps we could discuss non-technical aspects of this on slack, rather than here?)