### PR TITLE
Attempt to get calgary back online

### DIFF
--- a/ca_ab_calgary/people.py
+++ b/ca_ab_calgary/people.py
@@ -18,7 +18,7 @@ class CalgaryPersonScraper(CanadianScraper):
             ward = ' '.join(node.xpath('.//strong//text()')[0].split()[:-1])
             yield self.councillor_data(url, name, ward)
 
-        mayor_node = page.xpath('//div[contains(@class, "cocis-image-panel")]')[0]
+        # mayor_node = page.xpath('//div[contains(@class, "cocis-image-panel")]')[0]
         photo_url = urljoin(COUNCIL_PAGE, mayor_node.xpath('.//img/@src')[0])
         name = mayor_node.xpath('.//a//text()')[0]
         mayor_page = self.lxmlize(MAYOR_PAGE)


### PR DESCRIPTION
https://scrapers.herokuapp.com/ is reporting Calgary offline with the following error:

Traceback (most recent call last):
  File "/app/reports/management/commands/update.py", line 66, in handle
    report.report = subcommand.handle(args, other)
  File "/app/.heroku/src/pupa/pupa/cli/commands/update.py", line 259, in handle
    report['scrape'] = self.do_scrape(juris, args, scrapers)
  File "/app/.heroku/src/pupa/pupa/cli/commands/update.py", line 151, in do_scrape
    report[scraper_name] = scraper.do_scrape(**scrape_args)
  File "/app/.heroku/src/pupa/pupa/scrape/base.py", line 101, in do_scrape
    for obj in self.scrape(**kwargs) or []:
  File "/app/scrapers/ca_ab_calgary/people.py", line 21, in scrape
    mayor_node = page.xpath('//div[contains(@class, "cocis-image-panel")]')[0]
IndexError: list index out of range