### PR TITLE
ET-2245 : inital commit of BC muni candidate scraper.

### DIFF
--- a/ca_bc_municipalities_candidates/__init__.py
+++ b/ca_bc_municipalities_candidates/__init__.py
@@ -1,0 +1,12 @@
+from utils import CanadianJurisdiction
+
+
+class BritishColumbiaMunicipalities(CanadianJurisdiction):
+    classification = 'government'
+    division_id = 'ocd-division/country:ca/province:bc'
+    division_name = 'British Columbia'
+    name = 'British Columbia Municipalities'
+    url = 'http://civicinfo.bc.ca'
+
+    def get_organizations(self):
+        return []

--- a/ca_bc_municipalities_candidates/people.py
+++ b/ca_bc_municipalities_candidates/people.py
@@ -1,0 +1,139 @@
+from utils import CanadianScraper, CanadianPerson as Person
+from opencivicdata.divisions import Division
+from pupa.scrape import Organization
+
+from collections import defaultdict
+from datetime import date
+
+COUNCIL_PAGE = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTP3PplANMDX5EkNBwLN1zz4IxDvUcMbT3L2l6RoA5Hr27p5NovyzlpV2wlBNAHsA8sdDxXdMQ78eF0/pub?gid=726311062&single=true&output=csv'
+
+
+class BritishColumbiaMunicipalitiesPersonScraper(CanadianScraper):
+    updated_at = date(2018, 9, 20)
+    contact_person = 'andrew@newmode.net'
+
+    def scrape(self):
+        exclude_divisions = {
+            #'ocd-division/country:ca/csd:5909052',  # Abbotsford
+            #'ocd-division/country:ca/csd:5915001',  # Langley (DM)
+            #'ocd-division/country:ca/csd:5915004',  # Surrey
+            #'ocd-division/country:ca/csd:5915015',  # Richmond
+            #'ocd-division/country:ca/csd:5915022',  # Vancouver
+            #'ocd-division/country:ca/csd:5915025',  # Burnaby
+            #'ocd-division/country:ca/csd:5915034',  # Coquitlam
+            #'ocd-division/country:ca/csd:5917021',  # Saanich
+            #'ocd-division/country:ca/csd:5917034',  # Victoria
+            #'ocd-division/country:ca/csd:5935010',  # Kelowna
+        }
+        exclude_districts = {
+            'Alberni-Clayoquot',
+            'Capital',
+            'Islands Trust',
+            'Sunshine Coast',
+        }
+        expected_roles = {
+            'candidate',
+        }
+        infixes = {
+            'CY': 'City',
+            'DM': 'District',
+            'IGD': 'District',
+            'IM': 'Municipal',
+            'RGM': 'Regional',
+            'T': 'Town',
+            'VL': 'Village',
+        }
+        duplicate_names = {
+        }
+        exceptional_names = {
+            'Françoise Raunet',
+            'Gölök Z Buday',
+            'Tiffany Paré',
+        }
+
+        names_to_ids = {}
+        for division in Division.get('ocd-division/country:ca').children('csd'):
+            type_id = division.id.rsplit(':', 1)[1]
+            print("DEBUG - DIVISION: " + division.name)
+            if type_id.startswith('59'):
+                if division.attrs['classification'] == 'IRI':
+                    continue
+                if division.name in names_to_ids:
+                    names_to_ids[division.name] = None
+                else:
+                    names_to_ids[division.name] = division.id
+
+        reader = self.csv_reader(COUNCIL_PAGE, header=True)
+        reader.fieldnames = [field.lower() for field in reader.fieldnames]
+
+        organizations = {}
+
+        birth_date = 1900
+        seen = set()
+
+        for row in reader:
+            name = row['full name']
+            district_name = row['district name']
+            print("DEBUG - NAME: " + name)
+
+            if not any(row.values()) or 'vacant' in name.lower() or not name or district_name in exclude_districts:
+                continue
+
+            if row['district id']:
+                division_id = 'ocd-division/country:ca/csd:{}'.format(row['district id'])
+            else:
+                division_id = names_to_ids[row['district name']]
+
+            if division_id in exclude_divisions:
+                continue
+            if not division_id:
+                raise Exception('unhandled collision: {}'.format(row['district name']))
+
+            division = Division.get(division_id)
+
+            division_name = division.name
+            organization_name = '{} {} Council'.format(division_name, infixes[division.attrs['classification']])
+
+            if division_id not in seen:
+                seen.add(division_id)
+                organizations[division_id] = Organization(name=organization_name, classification='government')
+                organizations[division_id].add_source(COUNCIL_PAGE)
+
+            organization = organizations[division_id]
+
+            role = row['primary role']
+            print("DEBUG - ROLE: " + role)
+            if role not in expected_roles:
+                raise Exception('unexpected role: {}'.format(role))
+
+            if row['district id']:
+                district = format(division_id)
+            else:
+                district = division_name
+
+            organization.add_post(role=role, label=district, division_id=division_id)
+
+            p = Person(primary_org='government', primary_org_name=organization_name, name=name, district=district, role=role)
+            p.add_source(COUNCIL_PAGE)
+            if row['source url']:
+                p.add_source(row['source url'])
+
+            if name in duplicate_names:
+                p.birth_date = str(birth_date)
+                birth_date += 1
+
+            if row['email']:
+                p.add_contact('email', row['email'])
+
+            if row['phone']:
+                p.add_contact('voice', row['phone'], 'legislature')
+
+            if row['twitter']:
+                p.add_link(row['twitter'])
+
+            p._related[0].extras['boundary_url'] = '/boundaries/census-subdivisions/{}/'.format(division_id.rsplit(':', 1)[1])
+
+            yield p
+
+        for organization in organizations.values():
+            yield organization


### PR DESCRIPTION
Initial commit of BC municipal candidate scraper.

A few things I'm not sure about:
 - 4 districts (Alberni-Clayoquot, Capital, Islands Trust and Sunshine Coast) fail to import.  I've excluded them for now but can't figure out why this is as they appear to import fine in the bc_municipalities scraper that I modeled from--that said we do seem to have regional districts separated out in sub sheets within the BC muni source sheet.
 - 3 Names (Françoise Raunet, Gölök Z Buday and Tiffany Paré) won't import.  I've thrown them in an array for now, but couldn't figure out how to address them after reviewing similar code in other CanadianScrapers.  I've anglicized them temporarily in the source csv to ensure that the scraper is successful.
 - I'm not 100% sure that I'm mapping twitter data properly.
 - we were excluding a bunch of divisions in the original BC muni scraper--I've commented out these exclusions, but I'm not certain why they were there in the original scraper to begin with.
 - fairly certain that all rows need 'candidate' as role but if there's some additional flexibility with this, I'd be grateful to know.