### PR TITLE
ET-3536 : image, phone and fax import.

### DIFF
--- a/ca_ab/people.py
+++ b/ca_ab/people.py
@@ -7,6 +7,8 @@ import lxml.html
 
 COUNCIL_PAGE = 'http://www.assembly.ab.ca/net/index.aspx?p=mla_csv'
 
+LEGISLATURE_NO = '30'
+
 PARTIES = {
     'AL': 'Alberta Liberal Party',
     'AP': 'Alberta Party',
@@ -40,8 +42,9 @@ class AlbertaPersonScraper(CanadianScraper):
             name_without_status = name.split(',')[0]
             detail_url = (
                 'http://www.assembly.ab.ca/net/index.aspx?'
-                'p=mla_contact&rnumber={0}&leg=29'.format(
-                    mla['Riding Number']
+                'p=mla_contact&rnumber={0}&leg={1}'.format(
+                    mla['Riding Number'],
+                    LEGISLATURE_NO
                 )
             )
             detail_page = self.lxmlize(detail_url)
@@ -60,9 +63,9 @@ class AlbertaPersonScraper(CanadianScraper):
                 p.add_contact('email', mla['Email'])
             elif mla.get('MLA Email'):
                 p.add_contact('email', mla['MLA Email'])
-            if mla['Phone Number']:
+            if mla['Phone Number'] and mla['Phone Number'] != 'Pending':
                 p.add_contact('voice', mla['Phone Number'], 'legislature')
-            if mla['Fax Number']:
+            if mla['Fax Number'] and mla['Fax Number'] != 'Pending':
                 p.add_contact('fax', mla['Fax Number'], 'legislature')
             yield p
 


### PR DESCRIPTION
This commit seems to get the Alberta scraper running again, but still errors out at the end of the process with:

`09:54:24 WARNING pupa: could not save RunPlan, no successful runs of ocd-jurisdiction/country:ca/province:ab/legislature yet
Traceback (most recent call last):
  File "/usr/local/bin/pupa", line 11, in <module>
    load_entry_point('pupa', 'console_scripts', 'pupa')()
  File "/src/scrapers-ca/src/pupa/pupa/cli/__main__.py", line 67, in main
    subcommands[args.subcommand].handle(args, other)
  File "/src/scrapers-ca/src/pupa/pupa/cli/commands/update.py", line 260, in handle
    return self.do_handle(args, other, juris)
  File "/src/scrapers-ca/src/pupa/pupa/cli/commands/update.py", line 307, in do_handle
    report['import'] = self.do_import(juris, args)
  File "/src/scrapers-ca/src/pupa/pupa/cli/commands/update.py", line 209, in do_import
    report.update(post_importer.import_directory(datadir))
  File "/src/scrapers-ca/src/pupa/pupa/importers/base.py", line 190, in import_directory
    return self.import_data(json_stream())
  File "/src/scrapers-ca/src/pupa/pupa/importers/base.py", line 227, in import_data
    obj_id, what = self.import_item(data)
  File "/src/scrapers-ca/src/pupa/pupa/importers/base.py", line 265, in import_item
    raise DuplicateItemError(data, obj, related.get('sources', []))
pupa.exceptions.DuplicateItemError: attempt to import data that would conflict with data already in the import: {'label': 'Calgary-South East', 'role': 'MLA', 'organization_id': 'ocd-organization/d1678b64-65c4-4434-ad6d-a29021546e77', 'division_id': 'ocd-division/country:ca/province:ab/ed:25', 'start_date': '', 'end_date': '', 'extras': {}} (already imported as MLA - Calgary-South East - Legislative Assembly of Alberta)
obj1 sources: []
obj2 sources: []
`