### PR TITLE
Update Moncton scraper

### DIFF
--- a/ca_nb_moncton/people.py
+++ b/ca_nb_moncton/people.py
@@ -1,12 +1,47 @@
-from utils import CSVScraper
+import json
+from collections import defaultdict
+
+import requests
+
+from utils import CanadianPerson as Person
+from utils import CanadianScraper
+
+# from https://open.moncton.ca/datasets/elected-officials/explore
+API_URL = "https://services1.arcgis.com/E26PuSoie2Y7bbyI/arcgis/rest/services/Elected_Officials/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson"
 
 
-class MonctonPersonScraper(CSVScraper):
-    # http://open.moncton.ca/datasets/elected-officials-contact-information
-    csv_url = "https://opendata.arcgis.com/datasets/d81d30cf2b0d4bf7ae7aea5b0acc9d5f_0.csv"
-    many_posts_per_area = True
-    corrections = {
-        "last name": {
-            "Th�riault": "Thériault",
-        },
-    }
+class MonctonPersonScraper(CanadianScraper):
+    def scrape(self):
+        seat_numbers = defaultdict(int)
+        data = json.loads(requests.get(API_URL).content)["features"]
+        assert len(data), "No Councillors found"
+
+        for item in data:
+            councillor = item["properties"]
+            ward = councillor["WardName"]
+            if ward != "Moncton":
+                ward = "Ward " + ward
+            role = councillor["Primary_role"]
+            if role != "Mayor":
+                seat_numbers[ward] += 1
+                district = ward + " (seat {})".format(seat_numbers[ward])
+            else:
+                district = ward
+            name = councillor["Name"]
+            email = councillor["Email"]
+            phone = councillor["Phone"]
+            fax = councillor["Fax"]
+
+            p = Person(primary_org="legislature", name=name, district=district, role=role)
+
+            if phone:
+                p.add_contact("voice", p.clean_telephone_number(phone), "legislature")
+            if fax:
+                p.add_contact("fax", p.clean_telephone_number(fax), "legislature")
+            if email:
+                p.add_contact("email", email)
+
+            p.image = councillor["Photo_URL"]
+            p.add_source(API_URL)
+
+            yield p


### PR DESCRIPTION
This PR updates the Moncton person scraper so that it gets its data from the updated data set that Moncton has put out. However, I could not find a permanent link to download the dataset as a csv file, so I used their link to the json representation of the data to scrape the information.