### PR TITLE
Update Oakville scraper

### DIFF
--- a/ca_on_oakville/people.py
+++ b/ca_on_oakville/people.py
@@ -1,12 +1,42 @@
-from utils import CSVScraper
+import re
+
+from utils import CanadianPerson as Person
+from utils import CanadianScraper
+
+COUNCIL_PAGE = "https://www.oakville.ca/town-hall/mayor-council-administration/mayor-council/"
 
 
-class OakvillePersonScraper(CSVScraper):
-    # https://portal-exploreoakville.opendata.arcgis.com/datasets/99b4f905aa5b4bf9a3ada765164a98c1_0
-    csv_url = "https://opendata.arcgis.com/datasets/99b4f905aa5b4bf9a3ada765164a98c1_0.csv"
-    corrections = {
-        "primary role": {
-            "Town Councillor": "Councillor",
-            "Regional and Town Councillor": "Regional Councillor",
-        },
-    }
+class OakvillePersonScraper(CanadianScraper):
+    def scrape(self):
+        page = self.lxmlize(COUNCIL_PAGE)
+
+        councillors = page.xpath('//div[@class="card h-100"]')
+        assert len(councillors), "No Councillors found"
+
+        for councillor in councillors:
+            district_role = councillor.xpath(".//div[@class='user-function']/text()")[0]
+            if "Mayor" in district_role:
+                district = "Oakville"
+                role = district_role
+            else:
+                district, role = re.split(r"(?<=\d)\s+", district_role, 1)
+                if "Regional" in role:
+                    role = "Regional Councillor"
+                else:
+                    role = "Councillor"
+
+            name = councillor.xpath(".//div[@class='user-name']/text()")[0]
+            email = self.get_email(councillor)
+            phone = self.get_phone(councillor)
+            url = councillor.xpath('.//a[@class="btn"]/@href')[0]
+
+            p = Person(primary_org="legislature", name=name, district=district, role=role)
+            p.image = councillor.xpath(".//img/@src")[0]
+
+            p.add_contact("email", email)
+            p.add_contact("voice", phone, "legislature")
+
+            p.add_source(COUNCIL_PAGE)
+            p.add_source(url)
+
+            yield p


### PR DESCRIPTION
This PR rewrites the Oakville scraper to scrape information from the town council's website instead of an outdated csv file