### PR TITLE
Update Waterloo Region scraper

### DIFF
--- a/ca_on_waterloo_region/__init__.py
+++ b/ca_on_waterloo_region/__init__.py
@@ -15,15 +15,6 @@ class Waterloo(CanadianJurisdiction):
 
         organization.add_post(role="Chair", label=self.division_name, division_id=self.division_id)
         organization.add_post(
-            role="Regional Councillor", label="Cambridge", division_id="ocd-division/country:ca/csd:3530010"
-        )
-        organization.add_post(
-            role="Regional Councillor", label="Kitchener", division_id="ocd-division/country:ca/csd:3530013"
-        )
-        organization.add_post(
-            role="Regional Councillor", label="Waterloo", division_id="ocd-division/country:ca/csd:3530016"
-        )
-        organization.add_post(
             role="Regional Councillor", label="North Dumfries", division_id="ocd-division/country:ca/csd:3530004"
         )
         organization.add_post(
@@ -35,19 +26,19 @@ class Waterloo(CanadianJurisdiction):
         organization.add_post(
             role="Regional Councillor", label="Woolwich", division_id="ocd-division/country:ca/csd:3530035"
         )
-        for seat_number in range(1, 3):
+        for seat_number in range(1, 4):
             organization.add_post(
                 role="Regional Councillor",
                 label="Cambridge (seat {})".format(seat_number),
                 division_id="ocd-division/country:ca/csd:3530010",
             )
-        for seat_number in range(1, 5):
+        for seat_number in range(1, 6):
             organization.add_post(
                 role="Regional Councillor",
                 label="Kitchener (seat {})".format(seat_number),
                 division_id="ocd-division/country:ca/csd:3530013",
             )
-        for seat_number in range(1, 3):
+        for seat_number in range(1, 4):
             organization.add_post(
                 role="Regional Councillor",
                 label="Waterloo (seat {})".format(seat_number),

--- a/ca_on_waterloo_region/people.py
+++ b/ca_on_waterloo_region/people.py
@@ -1,15 +1,58 @@
 import re
+from collections import defaultdict
 
-from utils import CSVScraper
+from utils import CanadianPerson as Person
+from utils import CanadianScraper
+
+COUNCIL_PAGE = "https://www.regionofwaterloo.ca/en/regional-government/council.aspx"
 
 
-class WaterlooPersonScraper(CSVScraper):
-    # https://rowopendata-rmw.opendata.arcgis.com/datasets/a6f9364a68644b628ae7faa3b931b1b6_0
-    csv_url = "https://opendata.arcgis.com/datasets/a6f9364a68644b628ae7faa3b931b1b6_0.csv"
-    corrections = {
-        "district name": lambda value: re.sub(r"(?:City|Region|Township) of ", "", value),
-        "primary role": {
-            "Regional Chair": "Chair",
-        },
-        "twitter": lambda value: re.sub(r"^@", "https://twitter.com/", value),
-    }
+class WaterlooPersonScraper(CanadianScraper):
+    def scrape(self):
+        page = self.lxmlize(COUNCIL_PAGE)
+
+        municipalities = page.xpath("//table[1]//tr[not(.//a)]")
+        assert len(municipalities), "No municipalities found"
+
+        seat_numbers = defaultdict(int)
+        for municipality in municipalities:
+            area = municipality.text_content().strip()
+            area = re.sub(r"(?:City|Region|Township) of ", "", area)
+
+            councillors = municipality.xpath("./following-sibling::tr[1]//a[not(@target)]")
+            assert len(councillors), "No councillors found for {}".format(area)
+
+            for councillor in councillors:
+                name = councillor.text_content()
+                url = councillor.xpath("./@href")[0]
+                page = self.lxmlize(url)
+
+                if re.search("Waterloo|Cambridge|Kitchener", area):
+                    seat_numbers[area] += 1
+                    district = "{} (seat {})".format(area, seat_numbers[area])
+                else:
+                    district = area
+                if "Regional Council" in area:
+                    district = "Waterloo"
+                    role = "Chair"
+                else:
+                    role = "Regional Councillor"
+
+                p = Person(primary_org="legislature", name=name, district=district, role=role)
+                image = page.xpath('.//img[@class="Right"]/@src')
+                if image:
+                    p.image = image[0]
+
+                email = self.get_email(page)
+                phone = self.get_phone(page)
+                links = page.xpath('//div[@id="printArea"]//p[1]//@href[not(contains(., "mail"))]')
+                if links:
+                    for link in links:
+                        p.add_link(link)
+                p.add_contact("email", email)
+                p.add_contact("voice", phone, "legislature")
+
+                p.add_source(COUNCIL_PAGE)
+                p.add_source(url)
+
+                yield p


### PR DESCRIPTION
Changed the roles so that all of the regional councillors would have seat numbers and wrote a new scraper because the dataset is not up-to-date.