### PR TITLE
Add support for cloudflare obfuscated emails in get_email method

### DIFF
--- a/ca_bc_burnaby/people.py
+++ b/ca_bc_burnaby/people.py
@@ -12,16 +12,6 @@ class BurnabyPersonScraper(CanadianScraper):
         councillors = page.xpath("//a[@class='biography__link']/@href")
         assert len(councillors), "No councillors found"
         for person_url in councillors:
-
-            def decode_email(e):
-                de = ""
-                k = int(e[:2], 16)
-
-                for i in range(2, len(e) - 1, 2):
-                    de += chr(int(e[i : i + 2], 16) ^ k)
-
-                return de
-
             page = self.lxmlize(person_url)
 
             role, name = page.xpath("//h1/span")[0].text_content().strip().split(" ", 1)
@@ -29,9 +19,7 @@ class BurnabyPersonScraper(CanadianScraper):
 
             contact_node = page.xpath('//div[@class="contact"]')[0]
 
-            email = page.xpath('//div[@class = "contact__detail contact__detail--email"]/a/@href')[0]
-            decoded_email = decode_email(email.split("#", 1)[1])  # cloudflare encrypts the email data
-
+            email = self.get_email(contact_node)
             phone = self.get_phone(contact_node, area_codes=[604, 778])
 
             if role == "Mayor":
@@ -44,7 +32,7 @@ class BurnabyPersonScraper(CanadianScraper):
             p.add_source(COUNCIL_PAGE)
             p.add_source(person_url)
             if email:
-                p.add_contact("email", decoded_email)
+                p.add_contact("email", email)
             if phone:
                 p.add_contact("voice", phone, "legislature")
             yield p

--- a/ca_pe_charlottetown/people.py
+++ b/ca_pe_charlottetown/people.py
@@ -8,15 +8,6 @@ COUNCIL_PAGE = "https://www.charlottetown.ca/mayor___council/city_council/meet_m
 
 class CharlottetownPersonScraper(CanadianScraper):
     def scrape(self):
-        def decode_email(e):
-            de = ""
-            k = int(e[:2], 16)
-
-            for i in range(2, len(e) - 1, 2):
-                de += chr(int(e[i : i + 2], 16) ^ k)
-
-            return de
-
         page = self.lxmlize(COUNCIL_PAGE, user_agent="Mozilla/5.0")
 
         nodes = page.xpath('//div[@id="ctl00_ContentPlaceHolder1_ctl13_divContent"]/*')
@@ -52,14 +43,8 @@ class CharlottetownPersonScraper(CanadianScraper):
 
             p.image = image
 
-            for node in group:
-                email_node = node.xpath("//a[span/@data-cfemail]")
-                if email_node:
-                    email = email_node[0].xpath("./@href")[0].split("#")[1]
-                    break
-
-            decoded_email = decode_email(email).split("?")[0]
-            p.add_contact("email", decoded_email)
+            email = self.get_email(para)
+            p.add_contact("email", email)
 
             for text in para.xpath('.//strong[contains(., "Phone")]/following-sibling::text()'):
                 if re.search(r"\d", text):

--- a/ca_qc_cote_saint_luc/people.py
+++ b/ca_qc_cote_saint_luc/people.py
@@ -7,15 +7,6 @@ COUNCIL_PAGE = "https://cotesaintluc.org/fr/affaires-municipales/membres-du-cons
 
 class CoteSaintLucPersonScraper(CanadianScraper):
     def scrape(self):
-        def decode_email(e):
-            de = ""
-            k = int(e[:2], 16)
-
-            for i in range(2, len(e) - 1, 2):
-                de += chr(int(e[i : i + 2], 16) ^ k)
-
-            return de
-
         page = self.lxmlize(COUNCIL_PAGE, user_agent=CUSTOM_USER_AGENT)
         councillors = page.xpath('//div/div[contains(@class, "gb-container gb-container-") and .//img]')
         assert len(councillors), "No councillors found"
@@ -39,13 +30,11 @@ class CoteSaintLucPersonScraper(CanadianScraper):
             blog = councillor.xpath(
                 './/p[contains(.,"Blog")]//@href[not(contains(., "twitter") or contains(., "facebook"))]'
             )
-            encrypted_email = councillor.xpath('.//@href[contains(., "email")]')[0].split("#")[1]
-            email = decode_email(encrypted_email)
 
             p = Person(primary_org="legislature", name=name, district=district, role=role)
             p.add_source(COUNCIL_PAGE)
 
-            p.add_contact("email", email)
+            p.add_contact("email", self.get_email(councillor))
             p.add_contact("voice", self.get_phone(councillor, area_codes=[514]), "legislature")
             p.image = image
             if twitter:

--- a/ca_qc_kirkland/people.py
+++ b/ca_qc_kirkland/people.py
@@ -8,15 +8,6 @@ COUNCIL_PAGE = "http://www.ville.kirkland.qc.ca/portrait-municipal/conseil-munic
 
 class KirklandPersonScraper(CanadianScraper):
     def scrape(self):
-        def decode_email(e):
-            de = ""
-            k = int(e[:2], 16)
-
-            for i in range(2, len(e) - 1, 2):
-                de += chr(int(e[i : i + 2], 16) ^ k)
-
-            return de
-
         page = self.lxmlize(COUNCIL_PAGE)
 
         councillors = page.xpath('//div[@class="container_content"]//tbody/tr')
@@ -39,8 +30,7 @@ class KirklandPersonScraper(CanadianScraper):
                 .replace(".", ",")  # correcting a typo
                 .replace(",-#-", " x")
             )
-            encrypted_email = councillor.xpath('.//@href[contains(., "email")]')[0].split("#")[1]
-            email = decode_email(encrypted_email)
+            email = self.get_email(councillor)
 
             p = Person(primary_org="legislature", name=name, district=district, role=role)
             p.add_source(COUNCIL_PAGE)


### PR DESCRIPTION
A number of municipal sites use cloudflare to obfuscate their emails. This means that if you want to get their emails you have to write custom code each time. However, they use a consistent function to do this obfuscation. This PR changes the get_email method to also scrape cloudflare protected emails and decode them. Several other scrapers are updated to make use of this change, simplifying their code significantly. 