### PR TITLE
fix(ca_pe_summerside): Refactor scraper for new site

### DIFF
--- a/ca_pe_summerside/people.py
+++ b/ca_pe_summerside/people.py
@@ -1,76 +1,54 @@
 import re
-from urllib.parse import urljoin
 
-from utils import CONTACT_DETAIL_TYPE_MAP
 from utils import CanadianPerson as Person
 from utils import CanadianScraper
 
-COUNCIL_PAGE = "http://city.summerside.pe.ca/mayor-and-council/pages/2012/2/councillors/"
-MAYOR_PAGE = "http://city.summerside.pe.ca/mayor-and-council/pages/2012/2/mayor/"
+COUNCIL_PAGE = "https://summerside.hosted.civiclive.com/mayor_and_council"
+
+
+def decode_email(hex_email):
+    decoded_email = ""
+    key = int(hex_email[:2], 16)
+
+    for i in range(2, len(hex_email) - 1, 2):
+        decoded_email += chr(int(hex_email[i : i + 2], 16) ^ key)
+
+    return decoded_email
 
 
 class SummersidePersonScraper(CanadianScraper):
     def scrape(self):
-        page = self.lxmlize(COUNCIL_PAGE, "iso-8859-1")
+        page = self.lxmlize(COUNCIL_PAGE, user_agent="Mozilla/5.0")
 
-        yield self.scrape_mayor()
-
-        councillors = page.xpath('//div[@class="articlebody-inside"]//p[contains(text(),"-")]')
+        councillors = page.xpath('//ul[@class="sidenav"]//a[contains(., "Mayor") or contains(., "Councillor")]/@href')
         assert len(councillors), "No councillors found"
-        for councillor in councillors:
-            url = councillor.xpath(".//a")[0].attrib["href"].replace("../", "")
-            page = self.lxmlize(url, "iso-8859-1")
+        for url in councillors:
+            page = self.lxmlize(url, user_agent="Mozilla/5.0")
 
-            name = (
-                page.xpath('//div[@class="articletitle"]/h1')[0]
-                .text_content()
-                .replace("Councillor", "")
-                .replace("Deputy Mayor", "")
-            )
-            district = "Ward {}".format(
-                re.sub(r"\D+", "", page.xpath('//div[@class="articlebody-inside"]/p')[0].text_content())
-            )
+            role, name = page.xpath('//div[@id="pagetitle"]')[0].text_content().split(" /")[0].split(" ", 1)
 
-            p = Person(primary_org="legislature", name=name, district=district, role="Councillor")
+            if role == "Mayor":
+                district = "Summerside"
+            else:
+                district = re.search(
+                    r"(?<=Ward\s\d:\s).*(?=\n|\s$|)",
+                    page.xpath('//div[contains(@id, "ContentPlaceHolder")]//img/parent::*')[0].text_content(),
+                ).group(0)
+                district = (
+                    district.replace(" -", "-").replace("- ", "-").replace("-", "—").replace("Councillor", "").strip()
+                )
+            p = Person(primary_org="legislature", name=name, district=district, role=role)
             p.add_source(COUNCIL_PAGE)
             p.add_source(url)
 
-            photo_url_rel = page.xpath('//div[@class="articlebody-inside"]/p/img/@src')[0].replace("/..", "")
-            p.image = urljoin(url, photo_url_rel)
+            photo = page.xpath('//div[contains(@id, "ContentPlaceHolder")]//img/@src')[0]
+            phone = self.get_phone(page)
+            hex_email = page.xpath('//div[contains(@id, "ContentPlaceHolder")]//@data-cfemail')[0]
+            email = decode_email(hex_email)
 
-            contacts = (
-                page.xpath('//div[@class="articlebody-inside"]/p')[1]
-                .text_content()
-                .replace("Biography", "")
-                .replace("Committees", "")
-                .split(":")
-            )
-            for i, contact in enumerate(contacts):
-                if i == 0 or not contact:
-                    continue
-                contact_type = re.findall(r"([A-Z][a-z]+)", contacts[i - 1])[0]
-                if contact_type != "Address":
-                    contact = re.split(r"[A-Z]", contact)[0]
-                contact_type = CONTACT_DETAIL_TYPE_MAP[contact_type]
-                p.add_contact(contact_type, contact, "" if contact_type == "email" else "legislature")
+            p.image = photo
+            p.add_contact("voice", phone, "legislature")
+            p.add_contact("email", email)
+            print(email)
+
             yield p
-
-    def scrape_mayor(self):
-        page = self.lxmlize(MAYOR_PAGE, "iso-8859-1")
-
-        name = page.xpath('//div[@class="articletitle"]/h1')[0].text_content().replace("Mayor", "")
-
-        p = Person(primary_org="legislature", name=name, district="Summerside", role="Mayor")
-        p.add_source(MAYOR_PAGE)
-        p.image = page.xpath('//div[@class="articlebody-inside"]/p/img/@src')[0].replace("..", "")
-
-        info = page.xpath('//div[@class="articlebody-inside"]/p')
-        phone = re.findall(r"to (.*)", info[1].text_content())[0]
-        address = info[3].text_content().replace("by mail: ", "") + " " + info[4].text_content()
-        email = self.get_email(info[5])
-
-        p.add_contact("voice", phone, "legislature")
-        p.add_contact("address", address, "legislature")
-        p.add_contact("email", email)
-
-        return p


### PR DESCRIPTION
One of the emails threw an error when using the get_email method because for some reason cloudflare didn't add the usual encoded email to the href attribute. I've added a workaround for this PR since it seems like a one-off occurrence, but I could make another PR to make the method more robust.