### PR TITLE
Fix BC scraper

### DIFF
--- a/ca_bc/people.py
+++ b/ca_bc/people.py
@@ -5,15 +5,15 @@ from utils import CanadianPerson as Person
 from utils import CanadianScraper
 
 COUNCIL_PAGE = "https://www.leg.bc.ca/members"
-query = """
-query GetMLAsByConstituency($parliamentId: Int!) {\n  allMemberParliaments(condition: {parliamentId: $parliamentId, active: true}) {\n    nodes {\n      image: imageBySmallImageId {\n        path\n        description\n        __typename\n      }\n      constituency: constituencyByConstituencyId {\n        name\n        __typename\n      }\n      member: memberByMemberId {\n        firstName\n        lastName\n        __typename\n      }\n      isCounsel\n      isDoctor\n      isHonourable\n      party: partyByPartyId {\n        name\n        abbreviation\n        __typename\n      }\n      nodeId\n      __typename\n    }\n    __typename\n  }\n}
-"""
-variables = {"parliamentId": 43}
+JSON = {
+    "query": "query GetMLAsByConstituency($parliamentId: Int!) {\n  allMemberParliaments(condition: {parliamentId: $parliamentId, active: true}) {\n    nodes {\n      image: imageBySmallImageId {\n        path\n        description\n        __typename\n      }\n      constituency: constituencyByConstituencyId {\n        name\n        __typename\n      }\n      member: memberByMemberId {\n        firstName\n        lastName\n        __typename\n      }\n      isCounsel\n      isDoctor\n      isHonourable\n      party: partyByPartyId {\n        name\n        abbreviation\n        __typename\n      }\n      nodeId\n      __typename\n    }\n    __typename\n  }\n}",
+    "variables": {"parliamentId": 43},
+}
 
 
 class BritishColumbiaPersonScraper(CanadianScraper):
     def scrape(self):
-        response = requests.post(url="https://lims.leg.bc.ca/graphql", json={"query": query, "variables": variables})
+        response = requests.post(url="https://lims.leg.bc.ca/graphql", json=JSON)
         data = json.loads(response.content.decode("utf-8"))
         members = data["data"]["allMemberParliaments"]["nodes"]
         assert len(members), "No members found"

--- a/ca_bc/people.py
+++ b/ca_bc/people.py
@@ -16,6 +16,7 @@ class BritishColumbiaPersonScraper(CanadianScraper):
         response = requests.post(url="https://lims.leg.bc.ca/graphql", json={"query": query, "variables": variables})
         data = json.loads(response.content.decode("utf-8"))
         members = data["data"]["allMemberParliaments"]["nodes"]
+        assert len(members), "No members found"
         for member in members:
             image = "https://lims.leg.bc.ca/public" + member["image"]["path"]
             district = member["constituency"]["name"]

--- a/ca_bc/people.py
+++ b/ca_bc/people.py
@@ -1,76 +1,28 @@
-import re
+import json
+import requests
 
 from utils import CanadianPerson as Person
 from utils import CanadianScraper
 
-COUNCIL_PAGE = "https://www.leg.bc.ca/_api/search/query?querytext='(contentclass:sts_listitem%20OR%20IsDocument:True)%20SPSiteUrl:/content%20ListId:8ecafcaa-2bf9-4434-a60c-3663a9afd175%20MLAActiveOWSBOOL:1%20-LastNameOWSTEXT:Vacant'&selectproperties='Picture1OWSIMGE,Title,Path'&&sortlist='LastNameSort:ascending'&rowlimit=100&QueryTemplatePropertiesUrl='spfile://webroot/queryparametertemplate.xml'"
+COUNCIL_PAGE = "https://www.leg.bc.ca/members"
+query = """
+query GetMLAsByConstituency($parliamentId: Int!) {\n  allMemberParliaments(condition: {parliamentId: $parliamentId, active: true}) {\n    nodes {\n      image: imageBySmallImageId {\n        path\n        description\n        __typename\n      }\n      constituency: constituencyByConstituencyId {\n        name\n        __typename\n      }\n      member: memberByMemberId {\n        firstName\n        lastName\n        __typename\n      }\n      isCounsel\n      isDoctor\n      isHonourable\n      party: partyByPartyId {\n        name\n        abbreviation\n        __typename\n      }\n      nodeId\n      __typename\n    }\n    __typename\n  }\n}
+"""
+variables = {"parliamentId": 43}
 
 
 class BritishColumbiaPersonScraper(CanadianScraper):
     def scrape(self):
-        parties = {
-            "BC NDP": "New Democratic Party of British Columbia",
-            "BC Liberal Party": "British Columbia Liberal Party",
-        }
-
-        page = self.lxmlize(COUNCIL_PAGE, xml=True)
-
-        nsmap = {"d": "http://schemas.microsoft.com/ado/2007/08/dataservices"}
-        members = page.xpath("//d:Cells", namespaces=nsmap)
-        assert len(members), "No members found"
+        response = requests.post(url="https://lims.leg.bc.ca/graphql", json={"query": query, "variables": variables})
+        data = json.loads(response.content.decode("utf-8"))
+        members = data["data"]["allMemberParliaments"]["nodes"]
         for member in members:
-            url = member.xpath('./d:element/d:Key[text()="Path"]/following-sibling::d:Value/text()', namespaces=nsmap)[
-                0
-            ]
-            if "vacant" in url.lower():
-                continue
-            page = self.lxmlize(url)
+            image = "https://lims.leg.bc.ca/public" + member["image"]["path"]
+            district = member["constituency"]["name"]
+            name = member["member"]["firstName"] + " " + member["member"]["lastName"]
+            party = member["party"]["name"]
 
-            name = (
-                page.xpath('//div[contains(@class, "BCLASS-pagetitle")]//h3/text()')[0]
-                .replace("Wm.", "")
-                .replace(", Q.C.", "")
-                .replace(", K.C.", "")
-                .strip()
-            )
-            district, party = cleanup_list(page.xpath('//div[@id="MinisterTitle"]/following-sibling::text()'))
-            party = parties.get(party, party)
-            p = Person(primary_org="legislature", name=name, district=district, role="MLA", party=party)
+            p = Person(primary_org="legislature", name=name, district=district, role="MLA", party=party, image=image)
             p.add_source(COUNCIL_PAGE)
-            p.add_source(url)
-
-            p.image = page.xpath('//img[contains(@src, "Members")]/@src')[0]
-
-            email = page.xpath('//div[@class="convertToEmail"]//text()')[0].strip()
-            if "#" in email:
-                email = email.split("#")[0]
-            if email:
-                p.add_contact("email", email)
-
-            office = ", ".join(cleanup_list(page.xpath('//h4[contains(text(), "Office:")]/ancestor::div/text()')))
-            office = re.sub(r"\s{2,}", " ", office)
-            p.add_contact("address", office, "legislature")
-
-            constituency = ", ".join(
-                cleanup_list(page.xpath('//h4[contains(text(), "Constituency:")]/ancestor::div[1]//text()'))
-            )
-            constituency = re.sub(r"\s{2,}", " ", constituency).split(", Phone")[0]
-            p.add_contact("address", constituency, "constituency")
-
-            phones = cleanup_list(page.xpath('//span[contains(text(), "Phone:")]/following-sibling::text()'))
-
-            office_phone = phones[0]
-            p.add_contact("voice", office_phone, "legislature")
-            if len(phones) > 1:
-                constituency_phone = phones[1]
-                p.add_contact("voice", constituency_phone, "constituency")
-
-            roles = page.xpath('//div[@id="MinisterTitle"]/text()')[0].strip()
-            if roles:
-                p.extras["roles"] = [roles]
 
             yield p
-
-
-def cleanup_list(dirty_list):
-    return list(filter(None, (x.strip() for x in dirty_list)))


### PR DESCRIPTION
Update after recent election results. Failed to scrape the dynamic content at `https://www.leg.bc.ca/members`, instead scrapping the graphql at `https://lims.leg.bc.ca/graphql`.