### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 ### Folder Structure
 
 **ca** - Federal level scraper
+
 **ca_<abbreviated province name>** - Provincial scraper. Ex. 'ca_ab'
+
 **ca_<abbreviated province name>_<municiplaity>** - Municipal scraper. Ex. 'ca_ab_calgary'
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# Canadian Legislative Scrapers [![Build Status](https://travis-ci.com/opencivicdata/scrapers-ca.png?branch=master)](https://travis-ci.com/opencivicdata/scrapers-ca)
+# Canadian Legislative Scrapers 
+
+## Overview
+[Pupa](https://github.com/opencivicdata/pupa) scrapers to collect Canadian legislative data at all three levels of government.
+
+
+### Folder Structure
+
+**ca** - Federal level scraper
+**ca_<abbreviated province name>** - Provincial scraper. Ex. 'ca_ab'
+**ca_<abbreviated province name>_<municiplaity>** - Municipal scraper. Ex. 'ca_ab_calgary'
 
 ## Usage
 
@@ -43,7 +53,7 @@ See the first few steps of [this wiki page](https://github.com/opennorth/represe
 
 ## Develop a scraper
 
-Read the [Pupa documentation](http://docs.opencivicdata.org/en/latest/scrape/basics.html) or an existing scraper's code.
+Read the [Open Civic documentation](https://open-civic-data-docs.readthedocs.io/en/latest/scrape/index.html) or an existing scraper's code.
 
 Avoid using the XPath `string()` function unless the expression is known to not have matches on some pages. Otherwise, scrapers may continue to run without error despite failing to find a match. A comment like `# can be empty` or `# allow string()` should accompany the use of `string()`.
 


### PR DESCRIPTION
- I removed the broken link to build status. Is there a current link that should be added instead?

- I added an overview section to add some clarity as to what is being scraped and the folder structure.

* I see a candidates scraper appears to be in the works in #460  that might break what I perceived as the convention. I could add that new folder to the list when available.

* I also wanted to provide clarity around the specific types of data being scraped. It took me some time to understand the focus of this repo seems to be collecting data on people. Then it took me more time to understand that pupa is setup to injest other types of data too. Would it be fair to add a line to the readme acknowledging the current focus, but an openness to contributions of other types of pupa scrapers too?

- I updated the broken link for documentation under the 'Develop a Scraper' section.