### PR TITLE
fix: update ca House of Commons scrapers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: quarterly
   skip: [pip-compile]
 default_language_version:
-    python: python3.10
+    python: python3.12
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.4

--- a/ca/__init__.py
+++ b/ca/__init__.py
@@ -36,8 +36,14 @@ class Canada(CanadianJurisdiction):
 
         for division in Division.get(self.division_id).children("ed"):
             valid_from = division.attrs.get("validFrom")
-            if valid_from and valid_from <= datetime.now().strftime("%Y-%m-%d") and valid_from < "2024-04-23":
-                lower.add_post(role="MP", label=division.name, division_id=division.id)
+            valid_through = getattr(division, "valid_through", None)
+            if (not valid_from):
+                continue
+            if valid_through and valid_through < datetime.now().strftime("%Y-%m-%d"):
+                continue
+            if valid_from > datetime.now().strftime("%Y-%m-%d"):
+                continue
+            lower.add_post(role="MP", label=division.name, division_id=division.id)
 
         # for ocd_type in ("province", "territory"):
         #     for province_or_territory in Division.get(self.division_id).children(ocd_type):

--- a/ca/__init__.py
+++ b/ca/__init__.py
@@ -37,7 +37,7 @@ class Canada(CanadianJurisdiction):
         for division in Division.get(self.division_id).children("ed"):
             valid_from = division.attrs.get("validFrom")
             valid_through = getattr(division, "valid_through", None)
-            if (not valid_from):
+            if not valid_from:
                 continue
             if valid_through and valid_through < datetime.now().strftime("%Y-%m-%d"):
                 continue

--- a/ca/people.py
+++ b/ca/people.py
@@ -138,8 +138,8 @@ class CanadaPersonScraper(CanadianScraper):
                     voice = phone_and_fax[0].replace("Telephone:", "").replace("Téléphone :", "").strip()
                     if len(phone_and_fax) > 1:
                         fax = phone_and_fax[1].replace("Fax:", "").replace("Télécopieur :", "").strip()
-                    else: 
-                        fax = False;
+                    else:
+                        fax = False
 
                     if voice:
                         m.add_contact("voice", voice, note)

--- a/ca/people.py
+++ b/ca/people.py
@@ -1,4 +1,8 @@
 import hashlib
+import re
+
+from opencivicdata.divisions import Division
+from unidecode import unidecode
 
 from utils import CanadianPerson as Person
 from utils import CanadianScraper
@@ -8,8 +12,20 @@ COUNCIL_PAGE_MALE = "https://www.ourcommons.ca/Members/en/search?caucusId=all&pr
 COUNCIL_PAGE_FEMALE = "https://www.ourcommons.ca/Members/en/search?caucusId=all&province=all&gender=F"
 IMAGE_PLACEHOLDER_SHA1 = ["e4060a9eeaf3b4f54e6c16f5fb8bf2c26962e15d"]
 
+TRANSLATION_TABLE = str.maketrans("\u2013\u2014-", "   ")
+CONSECUTIVE_WHITESPACE_REGEX = re.compile(r"\s+")
+DELETE_REGEX = re.compile(r"[\u200f]")
+CORRECTIONS = {
+    # Different names.
+    "Kelowna Lake Country": "Kelowna",
+    "Nonafot Nunavut": "Nunavut",
+    # Typographic errors.
+    "Northwest Territores": "Northwest Territories",
+}
+
 
 class CanadaPersonScraper(CanadianScraper):
+    normalized_names = {}
     """
     The CSV at http://www.parl.gc.ca/Parliamentarians/en/members/export?output=CSV
     accessible from http://www.parl.gc.ca/Parliamentarians/en/members has no
@@ -17,22 +33,28 @@ class CanadaPersonScraper(CanadianScraper):
     """
 
     def scrape(self):
+        # Create list mapping names to IDs.
+        for division in Division.get("ocd-division/country:ca").children("ed"):
+            if "2023" in division.id:
+                self.normalized_names[self.normalize_district(division.name)] = division.name
         genders = {"male": COUNCIL_PAGE_MALE, "female": COUNCIL_PAGE_FEMALE}
         for gender, url in genders.items():
             page = self.lxmlize(url)
             rows = page.xpath('//div[contains(@class, "ce-mip-mp-tile-container")]')
             yield from self.scrape_people(rows, gender)
 
+    def normalize_district(self, district):
+        # Ignore accents, hyphens, lettercase, and leading, trailing and consecutive whitespace.
+        district = unidecode(district.translate(TRANSLATION_TABLE)).title().strip()
+        district = DELETE_REGEX.sub("", CONSECUTIVE_WHITESPACE_REGEX.sub(" ", district))
+        return CORRECTIONS.get(district, district)
+
     def scrape_people(self, rows, gender):
         assert len(rows), "No members found"
         for row in rows:
             name = row.xpath('.//div[@class="ce-mip-mp-name"][1]')[0].text_content()
             constituency = row.xpath('.//div[@class="ce-mip-mp-constituency"][1]')[0].text_content()
-            constituency = constituency.replace("–", "—")  # n-dash, m-dash
-            if constituency == "Mont-Royal":
-                constituency = "Mount Royal"
-            if constituency == "C\u00f4te-du-Sud-Rivi\u00e8re-du-Loup-Kataskomiq-T\u00e9miscouata":
-                constituency = "Côte-du-Sud—Rivière-du-Loup— Kataskomiq—Témiscouata"
+            constituency = self.normalized_names[self.normalize_district(constituency)]
 
             province = row.xpath('.//div[@class="ce-mip-mp-province"][1]')[0].text_content()
 

--- a/ca/people.py
+++ b/ca/people.py
@@ -31,6 +31,8 @@ class CanadaPersonScraper(CanadianScraper):
             constituency = constituency.replace("–", "—")  # n-dash, m-dash
             if constituency == "Mont-Royal":
                 constituency = "Mount Royal"
+            if constituency == "C\u00f4te-du-Sud-Rivi\u00e8re-du-Loup-Kataskomiq-T\u00e9miscouata":
+                constituency = "Côte-du-Sud—Rivière-du-Loup— Kataskomiq—Témiscouata"
 
             province = row.xpath('.//div[@class="ce-mip-mp-province"][1]')[0].text_content()
 
@@ -136,6 +138,8 @@ class CanadaPersonScraper(CanadianScraper):
                     voice = phone_and_fax[0].replace("Telephone:", "").replace("Téléphone :", "").strip()
                     if len(phone_and_fax) > 1:
                         fax = phone_and_fax[1].replace("Fax:", "").replace("Télécopieur :", "").strip()
+                    else: 
+                        fax = False;
 
                     if voice:
                         m.add_contact("voice", voice, note)


### PR DESCRIPTION
Added checks to ensure that we only use divisions within their valid date range, as well as one correction for the constituency name. Fixed an issue where the variable `fax` was sometimes being retrieved while unbound.