### PR TITLE
feat: add optional callback to format district names from CSVs

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -303,6 +303,10 @@ class CSVScraper(CanadianScraper):
     """
     district_name_format_string = None
     """
+    A callable that formats the district name. If district_name_format_string is also specified it takes precendence. Rarely used.
+    """
+    district_name_format_callback = None
+    """
     A dictionary of district names to boundary URLs. Rarely used.
     """
     district_name_to_boundary_url = {}
@@ -447,6 +451,11 @@ class CSVScraper(CanadianScraper):
                     district = self.district_name_format_string.format(**row)
                 else:
                     district = self.jurisdiction.division_name
+            elif self.district_name_format_callback:
+                if row.get("district name"):
+                    district = self.district_name_format_callback(row["district name"])
+                else:
+                    district = self.district_name_format_callback(self.jurisdiction.division_name)
             elif row.get("district name"):
                 district = row["district name"]
             elif self.fallbacks.get("district name"):


### PR DESCRIPTION
This PR adds the option to provide a callback that formats the district names from a CSV. This can be specified on a scraper by scraper basis by implementing the function `district_name_format_callback(self, district_name)`. 

Currently the only option to format district names from CSVs is to provide a dictionary of every unformatted district name to the correctly formatted name. If we have a large number of district names that are formatted wrong in a consistent way this quickly becomes cumbersome. 

The motivation for this is that in the most recent iteration of their published dataset, St. Catharine's listed all the district names in uppercase and there was no easy way to correct it.